### PR TITLE
[RFC] fix (indexes): Fix indexing every field on the version schema

### DIFF
--- a/lib/clone-schema.js
+++ b/lib/clone-schema.js
@@ -11,8 +11,10 @@ module.exports = function (schema, mongoose) {
           var clonedPath = {};
 
           clonedPath[key] = path.options;
-          clonedPath[key].unique = false;
-          clonedPath[key].index = false;
+          delete clonedPath[key].index;
+          delete clonedPath[key].unique;
+          delete clonedPath[key].sparse;
+          clonedPath[key]._index = null;
 
           clonedSchema.add(clonedPath);
         }


### PR DESCRIPTION
#### What's this PR do?
This PR fixes the indexing of every schema attribute upon creating the version table

#### Where should the reviewer start?
Just a single commit, start there.

#### Any background context you want to provide?
We were seeing some errors about the limit of indexes on some versions tables, upon further investigation we found out that the cloned paths from this plugin was creating an issue with (at least) the current version of mongoose.